### PR TITLE
Fix to nrpe-runner; add --verbose option

### DIFF
--- a/nrpe-runner
+++ b/nrpe-runner
@@ -1,4 +1,8 @@
 #!/usr/bin/ruby
+#
+# https://github.com/deanwilson/sysadmin-scripts/raw/master/nrpe-runner
+#
+
 require 'rubygems'
 require 'optparse'
 require 'json'
@@ -12,7 +16,7 @@ options = {
 OptionParser.new do |opts|
   opts.on("-a", "--all")                   { |v| options['all'] = v }
   opts.on("-c", "--command COMMAND")       { |command|  options['command'] = command }
-  opts.on("-d", "--directory")             { |v| options['basedir'] = v }
+  opts.on("-d", "--directory DIRECTORY")   { |directory| options['basedir'] = directory }
   opts.on("-j", "--json")                  { |v| options['json'] = v }
   opts.on("-n", "--name NAME")             { |name| options['name'] = name }
   opts.on("-o", "--output-file FILENAME")  { |filename| options['output'] = filename }

--- a/nrpe-runner
+++ b/nrpe-runner
@@ -8,26 +8,34 @@ require 'optparse'
 require 'json'
 
 checks  = {}
-options = {
+@options = {
   'basedir' => '/etc/nrpe.d',
   'conf_ext' => '.cfg',
+  'verbose' => false,
 }
 
 OptionParser.new do |opts|
-  opts.on("-a", "--all")                   { |v| options['all'] = v }
-  opts.on("-c", "--command COMMAND")       { |command|  options['command'] = command }
-  opts.on("-d", "--directory DIRECTORY")   { |directory| options['basedir'] = directory }
-  opts.on("-j", "--json")                  { |v| options['json'] = v }
-  opts.on("-n", "--name NAME")             { |name| options['name'] = name }
-  opts.on("-o", "--output-file FILENAME")  { |filename| options['output'] = filename }
-  opts.on("-r", "--return RETCODE")        { |retcode|  options['retcode'] = retcode }
-  opts.on("-s", "--summary")               { |v| options['summary'] = v }
+  opts.on("-a", "--all")                   { |v| @options['all'] = v }
+  opts.on("-c", "--command COMMAND")       { |command|  @options['command'] = command }
+  opts.on("-d", "--directory DIRECTORY")   { |directory| @options['basedir'] = directory }
+  opts.on("-j", "--json")                  { |v| @options['json'] = v }
+  opts.on("-n", "--name NAME")             { |name| @options['name'] = name }
+  opts.on("-o", "--output-file FILENAME")  { |filename| @options['output'] = filename }
+  opts.on("-r", "--return RETCODE")        { |retcode|  @options['retcode'] = retcode }
+  opts.on("-v", "--verbose")               { |v| @options['verbose'] = v }
+  opts.on("-s", "--summary")               { |v| @options['summary'] = v }
 end.parse!
+
+def verbose (msg) 
+  if @options['verbose']
+    puts "#{Time.new}: #{msg}"
+  end
+end
 
 # build up the list of checks. Checks that appear more than once
 # overwrite the older instance
 
-Dir["#{options['basedir']}/*#{options['conf_ext']}"].each do |file|
+Dir["#{@options['basedir']}/*#{@options['conf_ext']}"].each do |file|
   File.open( file, 'r' ).each_line do |line|
     line.chomp!
 
@@ -44,16 +52,16 @@ end
 # just in case nothing is filtered.
 wanted = checks
 
-if options['name']
-  wanted = checks.reject { |k,v| ! k.include? options['name'] }
+if @options['name']
+  wanted = checks.reject { |k,v| ! k.include? @options['name'] }
 end
 
-if options['command']
-  wanted = checks.reject { |k,v| ! v.include? options['command'] }
+if @options['command']
+  wanted = checks.reject { |k,v| ! v.include? @options['command'] }
 end
 
-if options['name'] && options['command']
-  wanted = checks.reject { |k,v| (! k.include? options['name']) || (! v.include? options['command']) }
+if @options['name'] && @options['command']
+  wanted = checks.reject { |k,v| (! k.include? @options['name']) || (! v.include? @options['command']) }
 end
 
 details  = { }
@@ -65,18 +73,20 @@ ran = 0
 #########################
 wanted.each_pair do |name,command|
 
+  verbose "Running #{name} -- #{command}"
+
   output = %x{ #{command} }.chomp!
   ret = $?.to_i / 256 # magic number
 
-  if options['json']
+  if @options['json']
     details[name] = { 'command' => command, 'output' => output, 'returncode' => ret }
     next
   end
 
-  if options['all']
+  if @options['all']
     puts "#{name} => #{output}"
-  elsif options['retcode']
-    if options['retcode'].to_i == ret
+  elsif @options['retcode']
+    if @options['retcode'].to_i == ret
       puts "#{name} => #{output}"
     end
   else # default to showing everything broken
@@ -89,10 +99,10 @@ wanted.each_pair do |name,command|
   ran += 1
 end
 
-if options['summary']
+if @options['summary']
   puts "Ran #{ran} checks - OK #{statuses['0']}. WARN #{statuses['1']}, CRIT #{statuses['2']}, UNKNOWN #{statuses['3']}"
 end
 
-if options['json']
+if @options['json']
   puts details.to_json
 end


### PR DESCRIPTION
Hey Dean,

Here's a couple of changes I've ended up making to your nrpe-runner script, one is a bug fix (--directory did not work). I've added --verbose and a 'verbose' method, which involved changing 'options' to be a global (@options).

Anyhoo, great work, have implemented in dev at our site. I'll prob add a 'nrpe-blacklist' file at some point, as puppet run time is a sensitive issue here, and not all NRPE checks we have need to run. You interested in that as a patch?

Hopefully will get to catch up with you in London soon, it's been a while eh?

Cheers,

Mike
