### PR TITLE
Fix probable bug in directory overriding

### DIFF
--- a/nrpe-runner
+++ b/nrpe-runner
@@ -12,7 +12,7 @@ options = {
 OptionParser.new do |opts|
   opts.on("-a", "--all")                   { |v| options['all'] = v }
   opts.on("-c", "--command COMMAND")       { |command|  options['command'] = command }
-  opts.on("-d", "--directory")             { |v| options['basedir'] = v }
+  opts.on("-d", "--directory DIR")         { |dir| options['basedir'] = dir }
   opts.on("-j", "--json")                  { |v| options['json'] = v }
   opts.on("-n", "--name NAME")             { |name| options['name'] = name }
   opts.on("-o", "--output-file FILENAME")  { |filename| options['output'] = filename }


### PR DESCRIPTION
I have a sneaking suspicion this is a bug you don't run into because the default location is the same everywhere you go. 

The current version, when using the d flag simply sets basedir to true, which I'm guessing isn't what the intent was. This fixes it so I can override the directory.
